### PR TITLE
sanity 감소 시 카메라 흔들림 기능 구현

### DIFF
--- a/CameraController.cs
+++ b/CameraController.cs
@@ -1,24 +1,86 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class CameraController : MonoBehaviour
 {
-    [SerializeField]
-    GameObject _player = null;
+    public Transform player;  // 플레이어의 Transform
+    public Camera cam;        // 카메라
+    public float mouseSpeed = 100f; // 마우스 이동 속도
+    public float rotationSmoothTime = 0.1f; // 회전 부드러움 조정 시간
 
-    // 카메라와 플레이어 사이의 초기 오프셋 (수정 필요)
-    Vector3 offset = new Vector3(0.0f, 1.5f, -3.0f);
+    private float xRotation = 0f;  // 카메라의 수직 회전 각도
+    private float yRotation = 0f;  // 카메라의 수평 회전 각도
+    private float currentXRotation = 0f; // 현재 카메라의 수직 회전 값
+    private float currentYRotation = 0f; // 현재 카메라의 수평 회전 값
+    private float xRotationVelocity = 0f; // 수직 회전 값 변화 속도
+    private float yRotationVelocity = 0f; // 수평 회전 값 변화 속도
 
-    void LateUpdate()
+    //--------공격받으면 카메라가 흔들리는 기능 관련 코드---------------
+    private float shakeDuration = 0.5f;//흔들림 지속시간
+    private float shakeAmount = 0.7f;//흔들림 강도
+    private Vector3 originalPos;
+    private float noiseOffsetX;//펄린노이즈용 변수 추가-->연속적인 난수를 생성하는 펄린노이즈를 사용하여 코루틴 내에서의 Random.Range 사용보다 자연스러운 흔들림 유도 가능
+    private float noiseOffsetY;
+    void Start()
     {
-        if (_player != null)
-        {
-            // 플레이어의 위치에 오프셋을 더해 카메라의 위치를 설정
-            transform.position = _player.transform.position + offset;
+        cam.transform.localPosition = new Vector3(0, 0.5f, -0.1f); // 카메라를 플레이어 뒤로 이동
+        cam.transform.localRotation = Quaternion.identity; // 카메라의 회전을 초기화
+        originalPos = cam.transform.localPosition;//카메라 현재 위치
+        //펄린노이즈 적용을 위해 랜덤한 시작점을 설정
+        noiseOffsetX = Random.Range(0f, 1000f);
+        noiseOffsetY = Random.Range(0f,1000f);
+    }
 
-            // 카메라가 플레이어를 바라보도록 회전
-            transform.LookAt(_player.transform);
+    void Update()
+    {
+        Rotate();
+    }
+
+    void Rotate()
+    {
+        float mouseX = Input.GetAxisRaw("Mouse X") * mouseSpeed * Time.deltaTime;
+        float mouseY = Input.GetAxisRaw("Mouse Y") * mouseSpeed * Time.deltaTime;
+
+        // 목표 회전 값 계산
+        yRotation += mouseX;
+        xRotation -= mouseY;
+        xRotation = Mathf.Clamp(xRotation, -90f, 90f); // 수직 회전 값을 -90도에서 90도 사이로 제한
+
+        // 현재 회전 값을 목표 회전 값으로 부드럽게 이동
+        currentXRotation = Mathf.SmoothDamp(currentXRotation, xRotation, ref xRotationVelocity, rotationSmoothTime);
+        currentYRotation = Mathf.SmoothDamp(currentYRotation, yRotation, ref yRotationVelocity, rotationSmoothTime);
+
+        // 카메라의 회전 적용
+        cam.transform.localRotation = Quaternion.Euler(currentXRotation, 0, 0);
+        player.transform.rotation = Quaternion.Euler(0, currentYRotation, 0); // 플레이어 회전 조절
+    }
+
+    public void StartShake()// 공격을 받으면 카메라 흔들림을 시작. DecreaseSanity()가 호출될 때 호출.
+    {
+        StopAllCoroutines();//이전 흔들림이 있다면 중지함.
+        StartCoroutine(ShakeCoroutine());
+    }
+
+    private IEnumerator ShakeCoroutine()
+    {
+        float elapsed = 0.0f;
+        while(elapsed < shakeDuration)
+        {
+            elapsed+=Time.deltaTime;
+            float percentComplete = elapsed / shakeDuration;//흔들림이 완료되는 시간
+            float damper = 1.0f - Mathf.Clamp(percentComplete, 0.0f, 1.0f);//시간이 지날 수록 흔들림이 자연스럽게 감소하도록 한다.
+            
+            //펄린 노이즈를 사용한 흔들림 적용. elapsed*10을 사용하여 노이즈의 속도를 조절한다. 이 값을 높여서 더 빠른 흔들림을 연출할 수 있을듯.
+            float offsetX = Mathf.PerlinNoise(noiseOffsetX + elapsed*10f, 0f );
+            float offsetY = Mathf.PerlinNoise(0f, noiseOffsetY + elapsed * 10f);
+
+            //1-에서 1 사이의 값으로 변환
+            offsetX = (offsetX * 2.0f - 1.0f) * shakeAmount * damper;
+            offsetY = (offsetY * 2.0f - 1.0f) * shakeAmount * damper;
+            cam.transform.localPosition = originalPos + new Vector3(offsetX, offsetY, 0);//흔들린 위치를 카메라 로컬포지션에 적용
+            
+            yield return null;
         }
+        cam.transform.localPosition = originalPos;//카메라 원래 위치로 이동.
     }
 }

--- a/FanaticController.cs
+++ b/FanaticController.cs
@@ -1,0 +1,166 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+public class FanaticController : MonoBehaviour
+{
+    //광신도 캐릭터 컨트롤러
+//--------------------------에너미 행동 관련 변수-----------------------------------------
+    [SerializeField] private Transform Player;//플레이어의 트랜스폼
+    [SerializeField] private NavMeshAgent Agent; // Bake된 NavMesh에서 활동할 에너미
+    [SerializeField] private Animator Anim;
+    [SerializeField] private const float ChaseRange = 3.0f;//플레이어 추격 가능 범위
+    [SerializeField] private const float DetectionRange = 3.0f;// 플레이어 탐지 거리
+    [SerializeField] private const float AttackRange = 0.7f;// 공격 가능 범위
+    private Define.EnemyState state;//에너미 상태 변수
+    private float DistanceToPlayer;//플레이어와의 거리를 저장할 변수
+
+//--------------------------에너미 경로 계산 관련 변수------------------------------------
+    private List<Vector3> Path = new List<Vector3>();// A*알고리즘으로 계산된 경로를저장할 리스트
+    private int CurrentPathIndex = 0;// 에너미가 현재 이동중인 경로 지점의 인덱스. 처음에는 Path[0]으로 이동.
+
+    //--------------------------공격 및 정신력 감소 관련 변수------------------------------
+    public SanityManager sanityManager; // SanityManager를 참조
+    private bool canAttack = true; // 공격 가능 여부를 체크할 변수
+    private float attackCooldown = 3.0f;//공격 쿨타임
+    //------------------------------------------------------------------------------------
+    private void Start()
+    {
+        state = Define.EnemyState.IDLE;//초기상태 : IDLE
+        Agent = GetComponent<NavMeshAgent>();
+        Agent.isStopped = true;
+        Anim = GetComponent<Animator>();
+        sanityManager = GameObject.FindAnyObjectByType<SanityManager>(); // 추가: SanityManager 찾기
+        BeginPatrol();//처음에 탐지 시작
+    }
+
+    private void Update()
+    {
+        DistanceToPlayer = Vector3.Distance(transform.position, Player.position);//플레이어와 에너미 사이의 거리를 계산
+        switch (state)
+        { 
+            case Define.EnemyState.IDLE:
+                break;
+            case Define.EnemyState.WALKING:
+                Patrol();//경로에 따라 탐색을 계속 진행
+                break;
+            case Define.EnemyState.RUNNING:
+                UpdateChase();// 플레이어를 추격
+                break;
+            case Define.EnemyState.ATTACK:
+                UpdateAttack();//플레이어를 공격
+                break;
+        }    
+    }
+
+    private void Patrol()// 탐색상태
+    {
+        if(Agent.isOnNavMesh && Path.Count>0)
+        {
+            Agent.isStopped = false;
+            Agent.speed = 0.2f;
+
+            if(DistanceToPlayer <=DetectionRange && state!=Define.EnemyState.ATTACK)//탐지 범위 내에 플레이어가 존재하면 && 공격 상태가 아닐 때 추격을 시작한다.
+            {
+                SetState(Define.EnemyState.RUNNING, "RUNNING");
+                return;
+            }
+
+            if(!Agent.hasPath || Agent.remainingDistance < 1.0f)//현재 경로가 없거나, 목표 지점에 도달하면
+            {
+                if(CurrentPathIndex < Path.Count)//경로 상의 다음 지점으로 이동
+                {
+                    Agent.SetDestination(Path[CurrentPathIndex]);
+                    CurrentPathIndex++;//현재 이동중인 경로의 다음 경로로 이동할 것.
+                }
+                else// 경로 끝에 도달하면 새 경로 계산
+                {
+                    CalculateNewPath();
+                }
+            }
+        }
+    }
+
+    private void BeginPatrol()
+    {
+        SetState(Define.EnemyState.WALKING, "WALKING"); // 걸어다니며 탐색 시작
+        Agent.isStopped = false;
+        CalculateNewPath();// 새로운 경로를 계산
+        Debug.Log($"현재 플레이어와의 거리 : {DistanceToPlayer}" );
+        Debug.Log($"현재 상태 : {state}");
+    }
+
+    private void UpdateAttack()// 공격 후 -> 플레이어와의 거리가 공격 가능 범위를 넘어간 상태 && 플레이어와의 거리가 아직 탐지 범위에 포함될 때 다시 쫒아가 플레이어를 공격해야 함.
+    {
+        if(Agent.isOnNavMesh)
+        {
+            Agent.isStopped = true;//공격 시 그 자리에서 멈춤
+            SetState(Define.EnemyState.ATTACK, "ATTACK");
+            if(DistanceToPlayer > AttackRange)// 공격범위를 벗어났다면
+            {
+                UpdateChase();
+                return;
+            }           
+            if(canAttack)
+            {
+            StartCoroutine(AttackCooldown());
+            Debug.Log($"현재 플레이어와의 거리 : {DistanceToPlayer}" );
+            Debug.Log($"현재 상태 : {state}");
+            sanityManager.DecreaseSanity(); //정신력 감소 호출
+            //24.11 문제 : 한번 공격할 때 마다 sanity가 전부 감소되어버림--> 해결방안 : 공격 가능 여부를 체크하는 코루틴을 사용하여 공격 쿨타임을 설정, 공격이 가능할 때에만 sanity를 감소할 수 있도록.
+            }
+        } 
+    }
+
+    private void UpdateChase()
+    {
+        if(Agent.isOnNavMesh)
+        {
+                    Debug.Log($"현재 플레이어와의 거리 : {DistanceToPlayer}" );
+        Debug.Log($"현재 상태 : {state}");
+            SetState(Define.EnemyState.RUNNING, "RUNNING");
+            Agent.isStopped = false;
+            Agent.speed = 0.7f;
+            Agent.destination = Player.position;// 목적지를 플레이어 포지션으로 설정하여 추격
+            if(DistanceToPlayer > ChaseRange)//플레이어와의 거리가 추격 가능 범위를 벗어났다면
+            {
+                BeginPatrol();//탐지 상태로 전환 
+            }
+            else if(DistanceToPlayer < AttackRange)//공격 가능 범위까지 다가갔다면
+            {
+                UpdateAttack();
+                return;
+            }
+        }
+    }
+
+    private void CalculateNewPath()// 새로운 경로를 계산하는 메서드
+    {
+        Vector3 RandomDirection = Random.insideUnitSphere * 10.0f;// 반경 1을 갖는 구 안의 임의 지점 * 10으로 경로 설정
+        RandomDirection += transform.position;// 에너미 포지션 값에 랜덤 값을 더한다
+
+        NavMeshHit hit;
+        //SamplePosition((Vector3 sourcePosition, out NavmeshHit hit, float maxDistance, int areaMask)
+        // 샘플포지션 메서드 : areaMask에 해당하는 NavMesh 중에서, maxDistance 반경 내에서 sourcePosition에 최근접한 위치를 찾아 hit에 담는다.
+        if (NavMesh.SamplePosition(RandomDirection, out hit, 10.0f, NavMesh.AllAreas))
+        {
+            Path.Clear();
+            Path.Add(hit.position);//A* 알고리즘에 해당하는 경로 설정
+            CurrentPathIndex = 0;// 현재위치를 담는 변수 초기화
+            Agent.SetDestination(Path[CurrentPathIndex]);
+        }
+    }
+
+    private void SetState(Define.EnemyState NewState, string AnimationTrigger)// 상태변경 메서드
+    {
+        if (state != NewState) { state = NewState; Anim.SetTrigger(AnimationTrigger); }//불필요한 상태 변경을 최소화. 각각의 상태에 맞게 애니메이터의 트리거를 바꾸어준다
+    }
+    
+    private IEnumerator AttackCooldown()//공격 쿨타임을 관리하는 코루틴. attackCooldown만큼 대기 후 공격 가능상태로 전환
+    {
+        canAttack = false;
+        yield return new WaitForSeconds(attackCooldown);
+        canAttack = true;
+    }
+}

--- a/SanityManager.cs
+++ b/SanityManager.cs
@@ -1,0 +1,222 @@
+using TMPro;
+using UnityEngine;
+using System.Collections;
+using UnityEngine.SceneManagement; // 게임오버 시 씬을 재시작하기 위해 사용
+using System;
+
+public class SanityManager : MonoBehaviour
+{
+    // 약 먹는 사운드
+    public AudioClip eatingSound;
+
+    public TextMeshProUGUI sanityText; // 정신력 수치 UI 텍스트
+    public TextMeshProUGUI medicineText; // 회복약 수치 UI 텍스트
+
+    public int sanity; // 정신력 수치 --> 사용되는 정신력 수치는 소문자로 기재
+
+    public int maxSanity; // 최대 정신력 (난이도별)
+    public int medicine; // 회복약 개수
+
+    public string difficulty = "Normal";
+
+    private bool gameOverTriggered = false; // 게임오버 상태를 추적
+    private bool isRestoringSanity = false; // 정신력 회복 중인지 추적
+    private float countdownTime = 15f; // 정신력 0일 때 게임오버 시간
+    private float lastMedicineTime = -Mathf.Infinity; // 마지막으로 약을 먹은 시간
+
+    private IEnumerator countdownCoroutine; // 카운트다운 코루틴 참조 저장
+
+    //정신력 감소 타이머 추가. 정신력이 1, 2일 때 10초 경과 시 정신력 한 단계 하락.
+    private float sanityTimer = 0f;
+    [SerializeField]
+    private float sanityDecreaseInterval = 10.0f;// 정신력 지속시간.
+
+    // sanity 이벤트 추가 --> 정신력 ui 이벤트를 위해 게터세터를 선언할 변수는 SSanity로 기재
+    public event Action<int> OnSanityChanged;// sanity값에 따라 화면 효과를 다르게 하기 위해 이벤트 생성. SanityImageController에서 구독하여 사용할 것. 
+    public int SSanity { get { return sanity; } set { if (sanity != value) { sanity = value; OnSanityChanged?.Invoke(sanity); sanityTimer = 0f; } } }//SSanity값이 변경될 때 이벤트 발생. 정신력 변경 시 타이머 초기화 추가
+
+    private CameraController cameraController;//정신력 감소시 카메라 흔들림 효과 시작을 전달하기 위해 참조
+    
+    void Start()
+    {
+        // 난이도에 따라 초기 정신력 값 설정
+        SetDifficulty();
+        ResetSanity();
+        cameraController  = FindAnyObjectByType<CameraController>();
+    }
+
+    void Update()
+    {
+        // 테스트를 위해 Q 키를 누르면 정신력 감소
+        if (Input.GetKeyDown(KeyCode.Q))
+        {
+            DecreaseSanity();
+            Debug.Log($"now sanity : {sanity} ");
+
+        }
+
+        // 테스트를 위해 R 키를 누르면 정신력 회복
+        if (Input.GetKeyDown(KeyCode.R))
+        {
+            RestoreSanity();
+        }
+
+        // 테스트를 위해 M 키를 누르면 회복약 획득
+        if (Input.GetKeyDown(KeyCode.M))
+        {
+            AddMedicine();
+        }
+
+        //빌드 시 회복 키 제외 모두 삭제
+
+        if(SSanity == 1 || SSanity == 2)
+        {
+            sanityTimer += Time.deltaTime;
+            if(sanityTimer>=sanityDecreaseInterval)// 10초 넘어가면
+            {
+                DecreaseSanity();//정신력 감소
+                sanityTimer = 0f;//타이머 초기화.
+            }
+        }
+
+
+
+    }
+
+    // 난이도에 따라 최대 정신력 설정
+    private void SetDifficulty()
+    {
+        switch (difficulty)
+        {
+            case "Easy":
+                maxSanity = 5;
+                break;
+            case "Normal":
+                maxSanity = 3;
+                break;
+            default:
+                maxSanity = 3; // 기본값은 Normal
+                break;
+        }
+    }
+
+    public void DecreaseSanity()
+    {
+        // 정신력이 1 이상일 때만 감소
+        if (sanity > 0)
+        {
+            sanity--;
+
+            // UI 텍스트 업데이트
+            sanityText.text = sanity.ToString();
+
+            if(cameraController!=null)
+            {
+                cameraController.StartShake();//카메라 흔들림 시작
+            }
+
+            // 정신력이 0 이하로 떨어지면 게임오버를 지연시키는 코루틴 호출
+            if (sanity <= 0 && !gameOverTriggered)
+            {
+                sanity = 0;
+                sanityText.color = new Color32(230, 25, 5, 255); // 0일 시 붉은 색
+                gameOverTriggered = true; // 게임오버가 트리거되었음을 표시
+                if (countdownCoroutine != null) StopCoroutine(countdownCoroutine); // 기존 카운트다운 중지
+                countdownCoroutine = GameOverCountdown(countdownTime);
+                StartCoroutine(countdownCoroutine); // 카운트다운 시작
+            }
+
+        }
+    }
+
+    public void RestoreSanity()
+    {
+        // 현재 시간과 마지막으로 약을 먹은 시간 비교 및 회복 중인지 확인
+        if (!isRestoringSanity && Time.time - lastMedicineTime >= 5f) // 5초가 지났는지 확인
+        {
+            // 정신력이 최대치 이하일 때만 회복
+            if (SSanity < maxSanity)
+            {
+                if (medicine > 0)
+                {
+                    isRestoringSanity = true; // 회복 시작
+                    StartCoroutine(DelayedRestoreSanity()); // 5초 후 정신력 회복
+                    medicine--;
+                    medicineText.text = medicine.ToString();
+
+                    AudioManager.Instance.PlaySound(eatingSound); // AudioManager를 통해 사운드 재생
+
+                    lastMedicineTime = Time.time; // 현재 시간을 마지막 약 먹은 시간으로 기록
+                }
+            }
+        }
+        else
+        {
+            //Debug.Log("약을 다시 먹기 위해서는 5초를 기다려야 합니다.");
+        }
+    }
+
+    // 약을 먹은 후 5초 뒤에 정신력을 회복하는 코루틴
+    private IEnumerator DelayedRestoreSanity()
+    {
+        yield return new WaitForSeconds(5f); // 5초 대기
+
+        SSanity++;
+        sanityText.text = SSanity.ToString(); // UI 텍스트 업데이트
+
+        // 정신력 회복 시 게임오버 상태 초기화
+        if (gameOverTriggered && SSanity > 0)
+        {
+            if (countdownCoroutine != null) StopCoroutine(countdownCoroutine); // 카운트다운 중지
+            sanityText.color = new Color32(25, 25, 5, 255); // 회복 시 기본 색상으로
+            sanityText.text = sanity.ToString(); // 정신력 UI 업데이트
+            gameOverTriggered = false; // 게임오버 트리거 상태 초기화
+        }
+
+        isRestoringSanity = false; // 회복 완료
+    }
+
+    // 정신력을 초기화하는 함수
+    public void ResetSanity()
+    {
+        SSanity = maxSanity; // 초기화 시 최대 정신력으로 설정
+        sanityText.text = SSanity.ToString(); // UI 텍스트 업데이트
+        medicineText.text = medicine.ToString();
+        gameOverTriggered = false; // 게임오버 상태 초기화
+        if (countdownCoroutine != null)
+        {
+            StopCoroutine(countdownCoroutine); // 이전 카운트다운 중지
+            countdownCoroutine = null; // 카운트다운 코루틴 참조를 null로 설정
+        }
+    }
+
+    public void AddMedicine()
+    {
+        medicine++;
+
+        medicineText.text = medicine.ToString();
+    }
+
+    private IEnumerator GameOverCountdown(float delay)
+    {
+        float elapsedTime = 0f; // 경과 시간
+        while (elapsedTime < delay)
+        {
+            float remainingTime = delay - elapsedTime;
+            //sanityText.text = $"게임오버까지 {Mathf.Ceil(remainingTime)}초"; // 남은 시간 UI 업데이트
+            yield return new WaitForSeconds(1f); // 1초 대기
+            elapsedTime += 1f; // 경과 시간 업데이트
+        }
+        GameOver(); // 게임 오버 처리
+    }
+
+    // 게임 오버를 처리하는 함수
+    private void GameOver()
+    {
+        sanityText.text = "Game Over"; // test
+        // 게임오버 로직 추가
+        // SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+    }
+
+
+}


### PR DESCRIPTION
1) 정신력이 감소할 경우 카메라가 흔들리는 기능을 구현함. 
2) CameraController에 흔들림 지속시간, 흔들림 강도, 카메라 로컬포지션 변수를 추가하고, 코루틴으로 기능 구현 3) 연속적인 일련의 의사 난수 값을 생성하는 펄린 노이즈 기능을 사용하여 카메라 흔들림 효과를 자연스럽게 구현. elapsed 변수 값을 조절하여 노이즈 속도를 제어할 수 있으며, Random.Range를 사용하는 것 보다 훨씬 더 부드러운 노이즈 발생->노이즈 감소가 확인됨. 4) 광신도 공격 시 호출되는 DecreaseSanity() 호출 시 흔들리도록 적용해놓음. 향후 doctor의 공격 메서드, 공포 이벤트 조우 시에도 적용할 것  5) 아직 광신도 공격 부분에서, 공격 애니메이션 재생과 흔들림 연출 사이 간격 존재. 계속 수정할 것.