### PR TITLE
sanity 감소 시 카메라 흔들림 구현 + 광신도 공격 시 흔들림 호출 딜레이 해결

### DIFF
--- a/UI_InGame/CameraController.cs
+++ b/UI_InGame/CameraController.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 public class CameraController : MonoBehaviour
@@ -14,12 +15,20 @@ public class CameraController : MonoBehaviour
     private float xRotationVelocity = 0f; // 수직 회전 값 변화 속도
     private float yRotationVelocity = 0f; // 수평 회전 값 변화 속도
 
+    //--------공격받으면 카메라가 흔들리는 기능 관련 코드---------------
+    private float shakeDuration = 0.5f;//흔들림 지속시간
+    private float shakeAmount = 0.7f;//흔들림 강도
+    private Vector3 originalPos;
+    private float noiseOffsetX;//펄린노이즈용 변수 추가-->연속적인 난수를 생성하는 펄린노이즈를 사용하여 코루틴 내에서의 Random.Range 사용보다 자연스러운 흔들림 유도 가능
+    private float noiseOffsetY;
     void Start()
     {
-        // 카메라를 플레이어의 자식으로 설정
-        // cam.transform.SetParent(player);
         cam.transform.localPosition = new Vector3(0, 0.5f, -0.1f); // 카메라를 플레이어 뒤로 이동
         cam.transform.localRotation = Quaternion.identity; // 카메라의 회전을 초기화
+        originalPos = cam.transform.localPosition;//카메라 현재 위치
+        //펄린노이즈 적용을 위해 랜덤한 시작점을 설정
+        noiseOffsetX = Random.Range(0f, 1000f);
+        noiseOffsetY = Random.Range(0f,1000f);
     }
 
     void Update()
@@ -45,4 +54,38 @@ public class CameraController : MonoBehaviour
         cam.transform.localRotation = Quaternion.Euler(currentXRotation, 0, 0);
         player.transform.rotation = Quaternion.Euler(0, currentYRotation, 0); // 플레이어 회전 조절
     }
+
+    public void StartShake()// 공격을 받으면 카메라 흔들림을 시작. DecreaseSanity()가 호출될 때 호출.
+    {
+        StopAllCoroutines();//이전 흔들림이 있다면 중지함.
+        StartCoroutine(ShakeCoroutine());
+    }
+
+    private IEnumerator ShakeCoroutine()
+    {
+        float elapsed = 0.0f;
+        while(elapsed < shakeDuration)
+        {
+            elapsed+=Time.deltaTime;
+            float percentComplete = elapsed / shakeDuration;//흔들림이 완료되는 시간
+            float damper = 1.0f - Mathf.Clamp(percentComplete, 0.0f, 1.0f);//시간이 지날 수록 흔들림이 자연스럽게 감소하도록 한다.
+            
+            //펄린 노이즈를 사용한 흔들림 적용. elapsed*10을 사용하여 노이즈의 속도를 조절한다. 이 값을 높여서 더 빠른 흔들림을 연출할 수 있을듯.
+            float offsetX = Mathf.PerlinNoise(noiseOffsetX + elapsed*10f, 0f );
+            float offsetY = Mathf.PerlinNoise(0f, noiseOffsetY + elapsed * 10f);
+
+            //1-에서 1 사이의 값으로 변환
+            offsetX = (offsetX * 2.0f - 1.0f) * shakeAmount * damper;
+            offsetY = (offsetY * 2.0f - 1.0f) * shakeAmount * damper;
+            cam.transform.localPosition = originalPos + new Vector3(offsetX, offsetY, 0);//흔들린 위치를 카메라 로컬포지션에 적용
+            
+            yield return null;
+        }
+        cam.transform.localPosition = originalPos;//카메라 원래 위치로 이동.
+    }
+    // private IEnumerator DelayedShakeCoroutine()
+    // {
+    //     yield return new WaitForSeconds(1.0f);
+    //     StartCoroutine(ShakeCoroutine());
+    // }
 }

--- a/UI_InGame/FanaticController.cs
+++ b/UI_InGame/FanaticController.cs
@@ -1,0 +1,172 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+public class FanaticController : MonoBehaviour
+{
+    //광신도 캐릭터 컨트롤러
+//--------------------------에너미 행동 관련 변수-----------------------------------------
+    [SerializeField] private Transform Player;//플레이어의 트랜스폼
+    [SerializeField] private NavMeshAgent Agent; // Bake된 NavMesh에서 활동할 에너미
+    [SerializeField] private Animator Anim;
+    [SerializeField] private const float ChaseRange = 3.0f;//플레이어 추격 가능 범위
+    [SerializeField] private const float DetectionRange = 3.0f;// 플레이어 탐지 거리
+    [SerializeField] private const float AttackRange = 0.7f;// 공격 가능 범위
+    private Define.EnemyState state;//에너미 상태 변수
+    private float DistanceToPlayer;//플레이어와의 거리를 저장할 변수
+
+//--------------------------에너미 경로 계산 관련 변수------------------------------------
+    private List<Vector3> Path = new List<Vector3>();// A*알고리즘으로 계산된 경로를저장할 리스트
+    private int CurrentPathIndex = 0;// 에너미가 현재 이동중인 경로 지점의 인덱스. 처음에는 Path[0]으로 이동.
+
+    //--------------------------공격 및 정신력 감소 관련 변수------------------------------
+    public SanityManager sanityManager; // SanityManager를 참조
+    private bool canAttack = true; // 공격 가능 여부를 체크할 변수
+    private float attackCooldown = 3.0f;//공격 쿨타임
+    //------------------------------------------------------------------------------------
+    private void Start()
+    {
+        state = Define.EnemyState.IDLE;//초기상태 : IDLE
+        Agent = GetComponent<NavMeshAgent>();
+        Agent.isStopped = true;
+        Anim = GetComponent<Animator>();
+        sanityManager = GameObject.FindAnyObjectByType<SanityManager>(); // 추가: SanityManager 찾기
+        BeginPatrol();//처음에 탐지 시작
+    }
+
+    private void Update()
+    {
+        DistanceToPlayer = Vector3.Distance(transform.position, Player.position);//플레이어와 에너미 사이의 거리를 계산
+        switch (state)
+        { 
+            case Define.EnemyState.IDLE:
+                break;
+            case Define.EnemyState.WALKING:
+                Patrol();//경로에 따라 탐색을 계속 진행
+                break;
+            case Define.EnemyState.RUNNING:
+                UpdateChase();// 플레이어를 추격
+                break;
+            case Define.EnemyState.ATTACK:
+                UpdateAttack();//플레이어를 공격
+                break;
+        }    
+    }
+
+    private void Patrol()// 탐색상태
+    {
+        if(Agent.isOnNavMesh && Path.Count>0)
+        {
+            Agent.isStopped = false;
+            Agent.speed = 0.2f;
+
+            if(DistanceToPlayer <=DetectionRange && state!=Define.EnemyState.ATTACK)//탐지 범위 내에 플레이어가 존재하면 && 공격 상태가 아닐 때 추격을 시작한다.
+            {
+                SetState(Define.EnemyState.RUNNING, "RUNNING");
+                return;
+            }
+
+            if(!Agent.hasPath || Agent.remainingDistance < 1.0f)//현재 경로가 없거나, 목표 지점에 도달하면
+            {
+                if(CurrentPathIndex < Path.Count)//경로 상의 다음 지점으로 이동
+                {
+                    Agent.SetDestination(Path[CurrentPathIndex]);
+                    CurrentPathIndex++;//현재 이동중인 경로의 다음 경로로 이동할 것.
+                }
+                else// 경로 끝에 도달하면 새 경로 계산
+                {
+                    CalculateNewPath();
+                }
+            }
+        }
+    }
+
+    private void BeginPatrol()
+    {
+        SetState(Define.EnemyState.WALKING, "WALKING"); // 걸어다니며 탐색 시작
+        Agent.isStopped = false;
+        CalculateNewPath();// 새로운 경로를 계산
+        Debug.Log($"현재 플레이어와의 거리 : {DistanceToPlayer}" );
+        Debug.Log($"현재 상태 : {state}");
+    }
+
+    private void UpdateAttack()// 공격 후 -> 플레이어와의 거리가 공격 가능 범위를 넘어간 상태 && 플레이어와의 거리가 아직 탐지 범위에 포함될 때 다시 쫒아가 플레이어를 공격해야 함.
+    {
+        if(Agent.isOnNavMesh)
+        {      
+            if(canAttack)
+            {
+            Agent.isStopped = true;//공격 시 그 자리에서 멈춤
+            SetState(Define.EnemyState.ATTACK, "ATTACK");
+            StartCoroutine(AttackCooldown());
+            Debug.Log($"현재 플레이어와의 거리 : {DistanceToPlayer}" );
+            Debug.Log($"현재 상태 : {state}");
+            //sanityManager.DecreaseSanity(); //정신력 감소 호출
+            StartCoroutine(DelayDecreaseSanity());
+            }
+            if(DistanceToPlayer > AttackRange)// 공격범위를 벗어났다면
+            {
+                UpdateChase();
+                return;
+            }     
+        } 
+    }
+
+    private void UpdateChase()
+    {
+        if(Agent.isOnNavMesh)
+        {
+                    Debug.Log($"현재 플레이어와의 거리 : {DistanceToPlayer}" );
+        Debug.Log($"현재 상태 : {state}");
+            SetState(Define.EnemyState.RUNNING, "RUNNING");
+            Agent.isStopped = false;
+            Agent.speed = 0.7f;
+            Agent.destination = Player.position;// 목적지를 플레이어 포지션으로 설정하여 추격
+            if(DistanceToPlayer > ChaseRange)//플레이어와의 거리가 추격 가능 범위를 벗어났다면
+            {
+                BeginPatrol();//탐지 상태로 전환 
+            }
+            else if(DistanceToPlayer < AttackRange)//공격 가능 범위까지 다가갔다면
+            {
+                UpdateAttack();
+                return;
+            }
+        }
+    }
+
+    private void CalculateNewPath()// 새로운 경로를 계산하는 메서드
+    {
+        Vector3 RandomDirection = Random.insideUnitSphere * 10.0f;// 반경 1을 갖는 구 안의 임의 지점 * 10으로 경로 설정
+        RandomDirection += transform.position;// 에너미 포지션 값에 랜덤 값을 더한다
+
+        NavMeshHit hit;
+        //SamplePosition((Vector3 sourcePosition, out NavmeshHit hit, float maxDistance, int areaMask)
+        // 샘플포지션 메서드 : areaMask에 해당하는 NavMesh 중에서, maxDistance 반경 내에서 sourcePosition에 최근접한 위치를 찾아 hit에 담는다.
+        if (NavMesh.SamplePosition(RandomDirection, out hit, 10.0f, NavMesh.AllAreas))
+        {
+            Path.Clear();
+            Path.Add(hit.position);//A* 알고리즘에 해당하는 경로 설정
+            CurrentPathIndex = 0;// 현재위치를 담는 변수 초기화
+            Agent.SetDestination(Path[CurrentPathIndex]);
+        }
+    }
+
+    private void SetState(Define.EnemyState NewState, string AnimationTrigger)// 상태변경 메서드
+    {
+        if (state != NewState) { state = NewState; Anim.SetTrigger(AnimationTrigger); }//불필요한 상태 변경을 최소화. 각각의 상태에 맞게 애니메이터의 트리거를 바꾸어준다
+    }
+    
+    private IEnumerator AttackCooldown()//공격 쿨타임을 관리하는 코루틴. attackCooldown만큼 대기 후 공격 가능상태로 전환
+    {
+        canAttack = false;
+        yield return new WaitForSeconds(attackCooldown);
+        canAttack = true;
+    }
+
+    private IEnumerator DelayDecreaseSanity()
+    {
+        yield return new WaitForSeconds(1.0f);
+        sanityManager.DecreaseSanity();
+    }
+}


### PR DESCRIPTION
1) 광신도의 UpadateAttack() 호출 시 카메라 흔들림 메서드 호출과 공격 애니메이션 재생 간 간극 해결 -> 광신도의 공격 애니메이션을 클립을 수정하기보다, 광신도의 공격 메서드 호출 시 DecreaseSanity()호출 전 1초 대기시간을 주면, 광신도가 팔을 들어 공격하는 타이밍에 딱 맞게 sanity가 줄어들고 흔들림 효과가 발생함. 광신도 스크립트에만 적용함으로써 다른 에너미에서의 호출에 영향X